### PR TITLE
Add --no-proxy flag to YouTube Study Buddy CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repository contains the **open-source CLI package** for self-hosted use. A 
 - 🏷️ **Auto-Categorization** - ML-based subject detection
 - 📊 **Knowledge Graph** - Cross-reference related concepts
 - 📄 **PDF Export** - Multiple themes (Obsidian, Academic, Minimal)
+- 🌐 **Flexible Proxy Options** - Choose Tor proxy (default) or direct connection for low-volume use
 
 **[Technical Details](docs/TECHNICAL_DETAILS.md)** - LangGraph workflow, Docker setup, development guide
 


### PR DESCRIPTION
Adds --no-proxy flag to allow users to bypass Tor proxy for low-volume use.

Key changes:
- CLI: Added --no-proxy argument and YTSB_USE_PROXY env var support
- transcript_provider.py: New DirectTranscriptProvider class for direct fetching
- video_processor.py: Support for both "tor" and "direct" provider types
- Enhanced error messages with rate limit guidance
- Updated documentation with proxy configuration and rate limit info

Use cases:
- Development/testing
- Low-volume personal use (<50 videos/day from residential IPs)
- Faster processing when rate limits aren't a concern

Defaults to Tor proxy for safety. CLI flag takes precedence over env var.